### PR TITLE
add announcement-capabililty to termine

### DIFF
--- a/announce.go
+++ b/announce.go
@@ -144,7 +144,7 @@ Subject: %s
 func RunAnnounce() {
 	var nextRelevantDate time.Time
 
-	if err := db.QueryRow("SELECT date FROM termine WHERE date > NOW() AND override IS NULL ORDER BY date ASC LIMIT 1").Scan(&nextRelevantDate); err != nil {
+	if err := db.QueryRow("SELECT date FROM termine WHERE date > NOW() AND override = '' ORDER BY date ASC LIMIT 1").Scan(&nextRelevantDate); err != nil {
 		fmt.Fprintln(os.Stderr, "Kann nächsten Termin nicht auslesen:", err)
 		return
 	}

--- a/announce.go
+++ b/announce.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+	//"net/smtp"
+	"os/exec"
+	"text/template"
+	//"bufio"
+	"bytes"
+	"database/sql"
+)
+
+var cmdAnnounce = &Command{
+	UsageLine: "announce",
+	Short:     "Announced nächsten Stammtisch oder c1/4",
+	Long: `Announced den nächsten Stammtisch oder die nächste c1/4,
+je nachdem, was am nächsten Donnerstag ist.`,
+	Flag:         flag.NewFlagSet("announce", flag.ExitOnError),
+	NeedsDB:      true,
+	RegenWebsite: false,
+}
+
+func init() {
+	cmdAnnounce.Run = RunAnnounce
+}
+
+func isStammtisch(date time.Time) (stammt bool, err error) {
+	err = db.QueryRow("SELECT stammtisch FROM termine WHERE date = $1", date).Scan(&stammt)
+	return
+}
+
+func announceStammtisch(date time.Time) {
+	loc, err := getLocation(date)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Kann Location nicht auslesen:", err)
+		return
+	}
+
+	maildraft := `Liebe Treffler,
+
+am kommenden Donnerstag ist wieder Stammtisch. Diesmal sind wir bei {{.Location}}.
+
+Damit wir passend reservieren können, tragt bitte bis Dienstag Abend,
+18:00 Uhr unter [0] ein, ob ihr kommt oder nicht.
+
+
+[0] https://www.noname-ev.de/yarpnarp.html
+	`
+
+	mailtmpl := template.Must(template.New("maildraft").Parse(maildraft))
+	mailbuf := new(bytes.Buffer)
+	type data struct{
+		Location string
+	}
+	err = mailtmpl.Execute(mailbuf, data{loc})
+	mail := mailbuf.String()
+
+	sendAnnouncement("Bitte für Stammtisch eintragen", mail)
+
+}
+
+func announceC14(date time.Time) {
+
+	var vortragid sql.NullInt64
+	err := db.QueryRow("SELECT vortrag FROM termine WHERE date = $1", date).Scan(&vortragid)
+	fmt.Println(err)
+
+	type data struct{
+		Topic, Abstract, Speaker string
+	}
+	d := new(data)
+	err = db.QueryRow("SELECT topic FROM vortraege WHERE id = $1", vortragid).Scan(&d.Topic)
+	err = db.QueryRow("SELECT abstract FROM vortraege WHERE id = $1", vortragid).Scan(&d.Abstract)
+	err = db.QueryRow("SELECT speaker FROM vortraege WHERE id = $1", vortragid).Scan(&d.Speaker)
+
+	maildraft := `Liebe Treffler,
+
+die chaotische Viertelstunde am kommenden Donnerstag wird {{.Speaker}} über {{.Topic}} sprechen.
+
+Abstract:
+
+{{.Abstract}}
+	`
+
+	mailtmpl := template.Must(template.New("maildraft").Parse(maildraft))
+	mailbuf := new(bytes.Buffer)
+	err = mailtmpl.Execute(mailbuf, d)
+	mail := mailbuf.String()
+	sendAnnouncement(d.Topic, mail)
+}
+
+func sendAnnouncement(subject, msg string) error {
+	fromheader := "From: termine@noname-ev.de"
+	toheader := "To: cherti@letopolis.de"
+	subjectheader := "Subject: " + subject
+	fullmail := fromheader + "\n" + subjectheader + "\n" + toheader + "\n\n" + msg
+
+	fmt.Println(":: creating command")
+	cmd := exec.Command("/usr/sbin/sendmail", "-t")
+
+	fmt.Println(":: setting up stdin")
+	indump, err := cmd.StdinPipe()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Fehler beim Senden: ", err)
+	}
+
+	fmt.Println(":: write to stdin")
+	_, err = indump.Write([]byte(fullmail))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Fehler beim Senden: ", err)
+	}
+	indump.Close()
+
+	err = cmd.Run()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Fehler beim Senden: ", err)
+	}
+
+	return nil
+}
+
+func RunAnnounce() {
+	// get next donnerstag, bool stammtisch is true oder false
+	nextThursday := getNextThursdays(2)[1]
+	fmt.Println(nextThursday)
+	isStm, err := isStammtisch(nextThursday)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Kann stammtischiness nicht auslesen:", err)
+		return
+	}
+
+	if isStm {
+		announceStammtisch(nextThursday)
+	} else {
+		announceC14(nextThursday)
+	}
+
+}

--- a/announce.go
+++ b/announce.go
@@ -13,8 +13,8 @@ import (
 
 var cmdAnnounce = &Command{
 	UsageLine: "announce",
-	Short:     "Announced nächsten Stammtisch oder c1/4",
-	Long: `Announced den nächsten Stammtisch oder die nächste c1/4,
+	Short:     "Kündigt nächsten Stammtisch oder nächste c¼h an",
+	Long: `Announced den nächsten Stammtisch oder die nächste c¼h,
 je nachdem, was am nächsten Donnerstag ist.`,
 	Flag:         flag.NewFlagSet("announce", flag.ExitOnError),
 	NeedsDB:      true,
@@ -53,26 +53,25 @@ Damit wir passend reservieren können, tragt bitte bis Dienstag Abend,
 	type data struct {
 		Location string
 	}
-	err = mailtmpl.Execute(mailbuf, data{loc})
-	mail := mailbuf.String()
+	if err = mailtmpl.Execute(mailbuf, data{loc}); err != nil {
+		fmt.Fprintln(os.Stderr, "Fehler beim Füllen des Templates:", err)
+		return
+	}
+	mail := mailbuf.Bytes()
 
 	sendAnnouncement("Bitte für Stammtisch eintragen", mail)
-
 }
 
 func announceC14(date time.Time) {
-
-	type data struct {
-		Topic, Abstract, Speaker string
+	var data struct {
+		Topic,
+		Abstract,
+		Speaker string
 	}
 
-	d := new(data)
-
-	err := db.QueryRow("SELECT topic FROM vortraege WHERE date = $1", date).Scan(&d.Topic)
-	if err != nil {
-
+	if err := db.QueryRow("SELECT topic FROM vortraege WHERE date = $1", date).Scan(&data.Topic); err != nil {
 		if err == sql.ErrNoRows {
-			fmt.Println("Es gibt nächsten Donnerstag noch keine c1/4. :(")
+			fmt.Println("Es gibt nächsten Donnerstag noch keine c¼h. :(")
 			return
 		}
 
@@ -80,26 +79,23 @@ func announceC14(date time.Time) {
 		return
 	}
 
-	err = db.QueryRow("SELECT abstract FROM vortraege WHERE date = $1", date).Scan(&d.Abstract)
-	if err != nil {
+	if err := db.QueryRow("SELECT abstract FROM vortraege WHERE date = $1", date).Scan(&data.Abstract); err != nil {
 		fmt.Fprintln(os.Stderr, "Kann abstract nicht auslesen:", err)
 		return
 	}
 
-	err = db.QueryRow("SELECT speaker FROM vortraege WHERE date = $1", date).Scan(&d.Speaker)
-	if err != nil {
+	if err := db.QueryRow("SELECT speaker FROM vortraege WHERE date = $1", date).Scan(&data.Speaker); err != nil {
 		fmt.Fprintln(os.Stderr, "Kann speaker nicht auslesen:", err)
 		return
 	}
 
 	maildraft := `Liebe Treffler,
 
-am kommenden Donnerstag wird es um das Thema
+am kommenden Donnerstag wird {{.Speaker}} eine c¼h zum Thema
 
     {{.Topic}}
 
-gehen. Es spricht {{.Speaker}} zu uns.
-
+halten.
 
 Kommet zahlreich!
 
@@ -111,35 +107,26 @@ Wer mehr Informationen möchte:
 
 	mailtmpl := template.Must(template.New("maildraft").Parse(maildraft))
 	mailbuf := new(bytes.Buffer)
-	err = mailtmpl.Execute(mailbuf, d)
-	mail := mailbuf.String()
-	sendAnnouncement(d.Topic, mail)
+	if err := mailtmpl.Execute(mailbuf, data); err != nil {
+		fmt.Fprintln(os.Stderr, "Fehler beim Füllen des Templates:", err)
+		return
+	}
+	mail := mailbuf.Bytes()
+	sendAnnouncement(data.Topic, mail)
 }
 
-func sendAnnouncement(subject, msg string) error {
-	fromheader := "From: termine@noname-ev.de"
-	toheader := "To: cherti@letopolis.de"
+func sendAnnouncement(subject string, msg []byte) error {
+	fromheader := "From: frank@noname-ev.de"
+	toheader := "To: ccchd@ccchd.de"
 	subjectheader := "Subject: " + subject
-	fullmail := fromheader + "\n" + subjectheader + "\n" + toheader + "\n\n" + msg
+	fullmail := []byte(fromheader + "\n" + subjectheader + "\n" + toheader + "\n\n")
+	fullmail = append(fullmail, msg...)
 
-	fmt.Println(":: creating command")
 	cmd := exec.Command("/usr/sbin/sendmail", "-t")
 
-	fmt.Println(":: setting up stdin")
-	indump, err := cmd.StdinPipe()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Fehler beim Senden: ", err)
-	}
+	cmd.Stdin = bytes.NewReader(fullmail)
 
-	fmt.Println(":: write to stdin")
-	_, err = indump.Write([]byte(fullmail))
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Fehler beim Senden: ", err)
-	}
-	indump.Close()
-
-	err = cmd.Run()
-	if err != nil {
+	if err := cmd.Run(); err != nil {
 		fmt.Fprintln(os.Stderr, "Fehler beim Senden: ", err)
 	}
 
@@ -147,8 +134,7 @@ func sendAnnouncement(subject, msg string) error {
 }
 
 func RunAnnounce() {
-	// get next donnerstag, bool stammtisch is true oder false
-	nextThursday := getNextThursdays(3)[2]
+	nextThursday := getNextThursdays(1)[0]
 
 	isStm, err := isStammtisch(nextThursday)
 	if err != nil {

--- a/announce.go
+++ b/announce.go
@@ -118,7 +118,7 @@ Wer mehr Informationen möchte:
 	sendAnnouncement(data.Topic, mail)
 }
 
-func sendAnnouncement(subject string, msg []byte) error {
+func sendAnnouncement(subject string, msg []byte) {
 	fullmail := new(bytes.Buffer)
 	fmt.Fprintf(fullmail, `From: frank@noname-ev.de
 To: %s
@@ -128,7 +128,7 @@ Subject: %s
 
 	cmd := exec.Command("/usr/sbin/sendmail", "-t")
 
-	cmd.Stdin = fullmail //bytes.NewReader(fullmail)
+	cmd.Stdin = fullmail
 
 	stdout := new(bytes.Buffer)
 	cmd.Stdout = stdout
@@ -137,12 +137,8 @@ Subject: %s
 	if err := cmd.Run(); err != nil {
 		fmt.Fprintln(os.Stderr, "Fehler beim Senden der Mail: ", err)
 		fmt.Fprintln(os.Stderr, "Output von Sendmail:")
-		if _, err = io.Copy(os.Stderr, stdout); err != nil {
-			fmt.Fprintln(os.Stderr, "Fehler beim Ausgeben des sendmail-Outputs: ", err)
-		}
+		io.Copy(os.Stderr, stdout)
 	}
-
-	return nil
 }
 
 func RunAnnounce() {

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ var Commands = []*Command{
 	cmdPassword,
 	cmdYarpNarp,
 	cmdHelp,
+	cmdAnnounce,
 }
 
 func (cmd *Command) Name() string {


### PR DESCRIPTION
instead of doing announcements for stammtische and c1/4 by hand, we can automate that by calling `termine announce` as implemented by this pull-request. currently the target-mailadress is not yet set to the ccchd-mailinglist, this will be done as a finalizing step once the code is accepted for merge.
